### PR TITLE
Feature/add xref to inmates and release integrations

### DIFF
--- a/src/main/java/com/openlattice/integrations/pennington/ZuercherInmates.java
+++ b/src/main/java/com/openlattice/integrations/pennington/ZuercherInmates.java
@@ -67,7 +67,7 @@ public class ZuercherInmates {
                 .endEntity()
                 .addEntity( IntegrationAliases.JAIL_STAY_ALIAS )
                 .to( config.getJailStays() )
-                .updateType( UpdateType.Replace )
+                .updateType( UpdateType.PartialReplace )
                 .entityIdGenerator( IntegrationUtils::getInmateID )
                 .addProperty( EdmConstants.OL_ID_FQN, ZuercherConstants.INMATE_NUMBER )
                 .addProperty( EdmConstants.BOOKING_DATE_FQN )

--- a/src/main/java/com/openlattice/integrations/pennington/ZuercherInmates.java
+++ b/src/main/java/com/openlattice/integrations/pennington/ZuercherInmates.java
@@ -52,6 +52,7 @@ public class ZuercherInmates {
                 .to( config.getPeople() )
                 .updateType( UpdateType.Merge )
                 .addProperty( EdmConstants.PERSON_ID_FQN, ZuercherConstants.PARTY_ID )
+                .addProperty( EdmConstants.JACKET_NO_FQN, ZuercherConstants.PERSON_JACKET_ID )
                 .addProperty( EdmConstants.LAST_NAME_FQN, ZuercherConstants.LAST_NAME )
                 .addProperty( EdmConstants.FIRST_NAME_FQN, ZuercherConstants.FIRST_NAME )
                 .addProperty( EdmConstants.SSN_FQN, ZuercherConstants.SSN )

--- a/src/main/java/com/openlattice/integrations/pennington/ZuercherReleases.java
+++ b/src/main/java/com/openlattice/integrations/pennington/ZuercherReleases.java
@@ -53,6 +53,7 @@ public class ZuercherReleases {
                 .to( config.getPeople() )
                 .updateType( UpdateType.Merge )
                 .addProperty( EdmConstants.PERSON_ID_FQN, ZuercherConstants.PARTY_ID )
+                .addProperty( EdmConstants.JACKET_NO_FQN, ZuercherConstants.PERSON_JACKET_ID )
                 .addProperty( EdmConstants.LAST_NAME_FQN, ZuercherConstants.LAST_NAME )
                 .addProperty( EdmConstants.FIRST_NAME_FQN, ZuercherConstants.FIRST_NAME )
                 .addProperty( EdmConstants.SSN_FQN, ZuercherConstants.SSN )


### PR DESCRIPTION
- Added xref to release and inmate integrations 
- Made jail stay write a Partial Replace, in the case that a release is written before a intake, due to integration failure, or whatever.